### PR TITLE
Aug 2021 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# docker build . -t trello-cal-sync-image
+
+FROM ubuntu:20.04
+
+RUN apt update && apt-get -y install git make python3 python3-pip python3-venv vim virtualenvwrapper
+
+RUN mkdir /app
+
+WORKDIR /app
+
+VOLUME /app
+
+#RUN touch /app/run_trello_cal_sync.sh
+
+ENTRYPOINT /app/trello-cal-sync/run_trello_cal_sync.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,5 @@ WORKDIR /app
 
 VOLUME /app
 
-#RUN touch /app/run_trello_cal_sync.sh
-
 ENTRYPOINT /app/trello-cal-sync/run_trello_cal_sync.sh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-trello==0.16.0
-google-api-python-client==1.7.11
-google-auth-httplib2==0.0.3
-google-auth-oauthlib==1.11.2
+py-trello==0.18.0
+google-api-python-client==2.18.0
+google-auth-httplib2==0.1.0
+google-auth-oauthlib==0.4.5

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+docker run \
+    --rm \
+    --name trello-cal-sync-container \
+    -v trello-cal-sync-volume:"/app" \
+    -v "$(pwd)":"/app/trello-cal-sync" \
+    trello-cal-sync-image
+

--- a/run_trello_cal_sync.sh
+++ b/run_trello_cal_sync.sh
@@ -12,28 +12,36 @@ else
 	pip_exe="pip"
 fi
 
-cd ~
+if [ -d "/app" ]; then
+	working_dir="/app"
+else
+	working_dir=$HOME
+fi
+
+cd $working_dir
 
 needs_install=0
-if [ ! -d "./trello-cal-sync-env" ]; then
+if [ ! -d "$working_dir/trello-cal-sync-env" ]; then
 	echo "Creating virtualenv"
-	$python_exe -m venv ./trello-cal-sync-env
+	$python_exe -m venv $working_dir/trello-cal-sync-env
 	needs_install=1
 fi
 
-if [ -d "./trello-cal-sync-env/bin" ]; then
-	. ./trello-cal-sync-env/bin/activate
+if [ -d "$working_dir/trello-cal-sync-env/bin" ]; then
+	. $working_dir/trello-cal-sync-env/bin/activate
 else
-	. ./trello-cal-sync-env/Scripts/activate
+	. $working_dir/trello-cal-sync-env/Scripts/activate
 fi
 
 if [ $needs_install == 1 ]; then
 	echo "Installing requirements"
-	$pip_exe install -r ./trello-cal-sync/requirements.txt
+	$pip_exe install -r $working_dir/trello-cal-sync/requirements.txt
 fi
 
-cd ~/trello-cal-sync
+cd $working_dir/trello-cal-sync
 
-date >> trello_cal_sync.log
+date 
 
-$python_exe trello_cal_sync.py >> trello_cal_sync.log 2>> trello_cal_sync.log
+$python_exe trello_cal_sync.py
+
+


### PR DESCRIPTION
For some reason I can't figure out, this stopped working on Aug 25th around 9pm pacific time. There are timeout errors when trying to retrieve event items from the google calendar api. This happened even after upgrading to latest python packages.

This was running on ubuntu 18.04 w/ Python 3.6.9. I tried running it in a 20.04 container w/ Python 3.8.10 and it works. Guessing it is due to some quirk with the older python version.

